### PR TITLE
Bug Expiration

### DIFF
--- a/lib/jwt_keeper/datastore.rb
+++ b/lib/jwt_keeper/datastore.rb
@@ -1,5 +1,7 @@
 module JWTKeeper
   module Datastore
+    PREFIX = 'JWTKeeper:'.freeze
+
     class << self
       # @!visibility private
       def rotate(jti, seconds)
@@ -27,11 +29,13 @@ module JWTKeeper
 
       # @!visibility private
       def set_with_expiry(jti, seconds, type)
+        key = "#{PREFIX}#{jti}"
+
         with_redis do |redis|
           if redis.respond_to?(:call) # For RedisClient
-            redis.call('SETEX', jti, seconds, type)
+            redis.call('SETEX', key, seconds, type)
           elsif redis.respond_to?(:setex) # For Redis
-            redis.setex(jti, seconds, type)
+            redis.setex(key, seconds, type)
           else
             throw 'Bad Redis Connection'
           end
@@ -40,11 +44,13 @@ module JWTKeeper
 
       # @!visibility private
       def get(jti)
+        key = "#{PREFIX}#{jti}"
+
         with_redis do |redis|
           if redis.respond_to?(:call) # For RedisClient
-            redis.call('GET', jti)
+            redis.call('GET', key)
           elsif redis.respond_to?(:get) # For Redis
-            redis.get(jti)
+            redis.get(key)
           else
             throw 'Bad Redis Connection'
           end

--- a/lib/jwt_keeper/token.rb
+++ b/lib/jwt_keeper/token.rb
@@ -53,14 +53,14 @@ module JWTKeeper
     # @param token_jti [String] the token unique id
     # @return [void]
     def self.rotate(token_jti)
-      Datastore.rotate(token_jti, JWTKeeper.configuration.expiry.from_now.to_i)
+      Datastore.rotate(token_jti, JWTKeeper.configuration.expiry.to_i)
     end
 
     # Revokes a web token
     # @param token_jti [String] the token unique id
     # @return [void]
     def self.revoke(token_jti)
-      Datastore.revoke(token_jti, JWTKeeper.configuration.expiry.from_now.to_i)
+      Datastore.revoke(token_jti, JWTKeeper.configuration.expiry.to_i)
     end
 
     # Checks if a web token has been revoked


### PR DESCRIPTION
This pull request includes changes to the `JWTKeeper` library to improve the handling of JWT token storage and expiry in Redis. The most important changes include the introduction of a prefix for Redis keys and the modification of expiry time configuration.

Improvements to Redis key handling:

* [`lib/jwt_keeper/datastore.rb`](diffhunk://#diff-e6fb824a786c05ec8ebaa7d7296e2f2725ed36dfb9b30367bf879127a076b709R3-R4): Introduced a `PREFIX` constant to prepend to Redis keys, ensuring namespace separation for JWT tokens.
* [`lib/jwt_keeper/datastore.rb`](diffhunk://#diff-e6fb824a786c05ec8ebaa7d7296e2f2725ed36dfb9b30367bf879127a076b709R32-R38): Updated the `set_with_expiry` method to use the prefixed key when setting expiry times in Redis.
* [`lib/jwt_keeper/datastore.rb`](diffhunk://#diff-e6fb824a786c05ec8ebaa7d7296e2f2725ed36dfb9b30367bf879127a076b709R47-R53): Updated the `get` method to use the prefixed key when retrieving values from Redis.

Configuration changes:

* [`lib/jwt_keeper/token.rb`](diffhunk://#diff-2585d25a9ffc234a42d604bf192a4d9f586429c025ccb03cce35f5e5fc7cbba8L56-R63): Modified the `rotate` and `revoke` methods to use the `expiry.to_i` configuration instead of `expiry.from_now.to_i` fixing an issue causing tokens to not expire